### PR TITLE
Update grub revision number

### DIFF
--- a/pull.sh
+++ b/pull.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 VERSION=2.04
-REVISION=16
+REVISION=17
 
 wget http://deb.debian.org/debian/pool/main/g/grub2/grub2_$VERSION-$REVISION.debian.tar.xz
 tar xf grub2_$VERSION-$REVISION.debian.tar.xz


### PR DESCRIPTION
This commit adds changes to update grub revision number as old revision number is not to be found upstream anymore resulting in failure to build grub.