### PR TITLE
Add rectify-terminal-io.patch

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,9 @@
+grub2 (2.99-8) unstable; urgency=medium
+
+  * Add rectify-temrinal-io.patch
+
+ -- Umer Saleem <usaleem@ixsystems.com>  Wed, 31 Aug 2022 21:13:12 +0500
+
 grub2 (2.99-7) unstable; urgency=medium
 
   * Remove offending debian/patches/efi-variable-storage-minimise-writes.patch

--- a/pull.sh
+++ b/pull.sh
@@ -17,6 +17,9 @@ rm debian/patches/series.bak
 cp zpool-degraded-vdev.patch debian/patches
 echo 'zpool-degraded-vdev.patch' >> debian/patches/series
 
+cp rectify-terminal-io.patch debian/patches
+echo 'rectify-terminal-io.patch' >> debian/patches/series
+
 echo -e "$(cat changelog)\n\n$(cat debian/changelog)" > debian/changelog
 
 sed -i.bak "s/deb_version\s*:=.\+/deb_version\t\t:= "'"'"$VERSION-$REVISION"'"'"/" debian/rules

--- a/rectify-terminal-io.patch
+++ b/rectify-terminal-io.patch
@@ -1,0 +1,74 @@
+diff --git a/util/grub.d/00_header.in b/util/grub.d/00_header.in
+index b7135b655..5c6bc5213 100644
+--- a/util/grub.d/00_header.in
++++ b/util/grub.d/00_header.in
+@@ -252,27 +252,53 @@ fi
+ EOF
+ fi
+ 
+-case x${GRUB_TERMINAL_INPUT} in
+-  x)
+-    # Just use the native terminal
+-  ;;
+-  x*)
+-    cat << EOF
++#
++# If both 'serial' and 'gfxterm' are enabled, check if we can load
++# 'gfxterm' successfully. If gfxterm fails, terminal_output falls back
++# to 'console' by default which would cause double output in EFI boot
++# mode if serial is also enabled.
++#
++# 'gfxterm' would fail if there are no graphics option present on the
++# system and it outputs to graphics devices only. If we fail to load
++# 'gfxterm', reset terminal_input and temrinal_output to 'serial' only.
++#
++# If either serial or gfxterm is not enabled, follow the the default
++# path for routing terminal_input and terminal_output.
++#
++
++if [ "x$serial" = x1 ] && [ "x$gfxterm" = x1 ]; then
++  cat << EOF
++if terminal_output gfxterm; then
++  terminal_output --append serial
++  terminal_input ${GRUB_TERMINAL_INPUT}
++else
++  terminal_input serial
++  terminal_output serial
++fi
++EOF
++else
++  case x${GRUB_TERMINAL_INPUT} in
++    x)
++      # Just use the native terminal
++    ;;
++    x*)
++      cat << EOF
+ terminal_input ${GRUB_TERMINAL_INPUT}
+ EOF
+-  ;;
+-esac
++    ;;
++  esac
+ 
+-case x${GRUB_TERMINAL_OUTPUT} in
+-  x)
+-    # Just use the native terminal
+-  ;;
+-  x*)
+-    cat << EOF
++  case x${GRUB_TERMINAL_OUTPUT} in
++    x)
++      # Just use the native terminal
++    ;;
++    x*)
++      cat << EOF
+ terminal_output ${GRUB_TERMINAL_OUTPUT}
+ EOF
+-  ;;
+-esac
++    ;;
++  esac
++fi
+ 
+ if [ "x$gfxterm" = x1 ]; then
+     if [ "x$GRUB_THEME" != x ] && [ -f "$GRUB_THEME" ] \


### PR DESCRIPTION
During GRUB terminal input and output setup, we need to make sure that
graphics and serial console work properly for GRUB.

Using both 'console' and 'serial' as GRUB temrinal input and output in
EFI boot mode causes double output, since both 'console' and 'serial'
are writing to serial port. To fix this issue we use 'gfxterm' for EFI
boot mode and make sure that we fallback to serial output only, if
'gfxterm' fails.

For hardware that does not have any graphics option and rely on serial
port, 'gfxterm' would fail with error 'no suitable video mode'. Serial
console will still be enabled in this case.

This is a carry of https://github.com/truenas/middleware/pull/9761