### PR TITLE
Upstream grub2 rolled from 2.06-8.debian to 2.06-12.debian

### DIFF
--- a/pull.sh
+++ b/pull.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 VERSION=2.06
-REVISION=8
+REVISION=12
 
 wget http://deb.debian.org/debian/pool/main/g/grub2/grub2_$VERSION-$REVISION.debian.tar.xz
 tar xf grub2_$VERSION-$REVISION.debian.tar.xz


### PR DESCRIPTION
Build is currently broken.  It appears that the upstream has rolled from 2.06-8 to 2.06-12

See http://deb.debian.org/debian/pool/main/g/grub2/

----
**Some additional comments:**

- This took **ages**  to build on my (admittedly weak) build system
- Noticed what looks like some breakage wrt additional packages getting built, but this has been going on long time (e.g. search for "_error: Requested unknown package_" in [this](https://cdn1.tn.ixsystems.com/download.truenas.com/TrueNAS-SCALE-Angelfish-RC-To-Release/22.02.0.1/packages/grub2.log) or [this](https://ci.tn.ixsystems.net/jenkins/job/TrueNAS%20SCALE%20-%20Unstable/job/Build%20-%20TrueNAS%20SCALE%20(Full%20-%20Nightly%20ISO)/1180/artifact/src/logs/packages/grub2.log))

An extract...
```
dh_auto_configure -- PACKAGE_VERSION=""2.06-8"" PACKAGE_STRING="GRUB "2.06-8"" CC=gcc-12 TARGET_CC=gcc-12 --libdir=\${prefix}/lib --libexecdir=\${prefix}/lib --enable-grub-mkfont --disable-grub-emu-usb --with-platform=xen --target=i386 --program-prefix=""
dh_auto_configure: error: Requested unknown package grub-xen-i386 via -p/--package, expected one of: grub2 grub-linuxbios grub-efi grub-common grub2-common grub-emu grub-emu-dbg grub-pc-bin grub-pc-dbg grub-pc grub-rescue-pc grub-coreboot-bin grub-coreboot-dbg grub-coreboot grub-efi-ia32-bin grub-efi-ia32-dbg grub-efi-ia32 grub-efi-ia32-signed-template grub-efi-amd64-bin grub-efi-amd64-dbg grub-efi-amd64 grub-efi-amd64-signed-template grub-efi-ia64-bin grub-efi-ia64-dbg grub-efi-ia64 grub-efi-arm-bin grub-efi-arm-dbg grub-efi-arm grub-efi-arm64-bin grub-efi-arm64-dbg grub-efi-arm64 grub-efi-arm64-signed-template grub-ieee1275-bin grub-ieee1275-dbg grub-ieee1275 grub-firmware-qemu grub-uboot-bin grub-uboot-dbg grub-uboot grub-xen-bin grub-xen-dbg grub-xen grub-xen-host grub-yeeloong-bin grub-yeeloong-dbg grub-yeeloong grub-theme-starfield grub-mount-udeb
dh_auto_configure: warning: ignored unknown options in DH_OPTIONS
	cd obj/grub-xen-i386 && ../../configure --build=x86_64-linux-gnu --prefix=/usr --includedir=\${prefix}/include --mandir=\${prefix}/share/man --infodir=\${prefix}/share/info --sysconfdir=/etc --localstatedir=/var --disable-option-checking --disable-silent-rules --libdir=\${prefix}/lib/x86_64-linux-gnu --runstatedir=/run --disable-maintainer-mode --disable-dependency-tracking PACKAGE_VERSION=2.06-8 "PACKAGE_STRING=GRUB 2.06-8" CC=gcc-12 TARGET_CC=gcc-12 --libdir=\${prefix}/lib --libexecdir=\${prefix}/lib --enable-grub-mkfont --disable-grub-emu-usb --with-platform=xen --target=i386 --program-prefix=
checking build system type... x86_64-pc-linux-gnu
checking host system type... x86_64-pc-linux-gnu
```