### PR TITLE
mkrescue: add opt-in quirk to support copying the shim for secure-boot

### DIFF
--- a/changelog
+++ b/changelog
@@ -4,6 +4,7 @@ grub2 (2.12-1~bpo12+0) unstable; urgency=medium
   * Add sbat entry for TrueNAS
   * Backport 2025-02 CVE fixes
   * Bump upstream SBAT level to 5
+  * mkrescue: add opt-in quirk to support copying the shim for secure-boot
 
  -- Waqar <waqar@ixsystems.com>  Tue, 06 May 2025 10:00:00 +0500
 

--- a/pull.sh
+++ b/pull.sh
@@ -106,6 +106,9 @@ echo 'cve_2025_02_multiple/fs-xfs-Handle-root-inode-read-failure-in-grub_xfs_mou
 cp sbat_to_5.patch debian/patches
 echo 'sbat_to_5.patch' >> debian/patches/series
 
+cp truenas-mkrescue-install-signed-shim.patch debian/patches
+echo 'truenas-mkrescue-install-signed-shim.patch' >> debian/patches/series
+
 echo -e "$(cat changelog)\n\n$(cat debian/changelog)" > debian/changelog
 
 sed -i.bak "s/deb_version\s*:=.\+/deb_version\t\t:= "'"'"$VERSION-$REVISION"'"'"/" debian/rules

--- a/truenas-mkrescue-install-signed-shim.patch
+++ b/truenas-mkrescue-install-signed-shim.patch
@@ -1,0 +1,63 @@
+diff --git a/util/grub-mkrescue.c b/util/grub-mkrescue.c
+index abcc1c2..b9d3d98 100644
+--- a/util/grub-mkrescue.c
++++ b/util/grub-mkrescue.c
+@@ -845,13 +845,57 @@ main (int argc, char *argv[])
+       else if (source_dirs[GRUB_INSTALL_PLATFORM_I386_EFI])
+ 	grub_install_copy_file (img32, img_mac, 1);
+
++      /*
++       * TRUENAS EDIT START
++       * The following code is a quirk to support the TrueNAS CD Builder.
++       * It copies the signed shim and grub binaries to the EFI boot directory
++       * and creates a grub.cfg that loads the TrueNAS kernel.
++       * This is only needed for TrueNAS CD builds, and should not be used in
++       * other environments.
++       */
++      if (getenv("TRUENAS_CD_BUILDER_SHIM_QUIRK") && source_dirs[GRUB_INSTALL_PLATFORM_X86_64_EFI])
++        {
++          grub_util_info ("======\nNOTE: found TRUENAS_CD_BUILDER_SHIM_QUIRK in environment, enabling quirk!\n======");
++
++          /*
++           * /usr/lib/shim/shimx64.efi.signed -> efidir_efi_boot/BOOTx64.EFI
++           * /usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed -> efidir_efi_boot/grubx64.efi
++           */
++          const char *signed_shim_source = "/usr/lib/shim/shimx64.efi.signed";
++          char *signed_shim_target = xasprintf("%s/bootx64.efi", efidir_efi_boot);
++
++          const char *signed_grub_source = "/usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed";
++          char *signed_grub_target = xasprintf("%s/grubx64.efi", efidir_efi_boot);
++
++          char *efidir_debian = grub_util_path_concat(2, efidir_efi, "debian");
++          grub_install_mkdir_p(efidir_debian);
++          char *load_cfg = xasprintf("%s/grub.cfg", efidir_debian);
++          FILE *load_cfg_f = grub_util_fopen (load_cfg, "wb");
++          fprintf (load_cfg_f, "search --file --set=root /.disk/info\n");
++          fprintf (load_cfg_f, "set prefix=($root)/boot/grub\n");
++          fprintf (load_cfg_f, "source $prefix/x86_64-efi/grub.cfg\n");
++          fclose (load_cfg_f);
++
++          rv = grub_util_exec ((const char * []) { "cp", signed_shim_source, signed_shim_target, NULL });
++          if (rv != 0)
++            grub_util_error ("`%s` invocation failed\n", "cp");
++
++          rv = grub_util_exec ((const char * []) { "cp", signed_grub_source, signed_grub_target, NULL });
++          if (rv != 0)
++            grub_util_error ("`%s` invocation failed\n", "cp");
++          free(load_cfg);
++          free(efidir_debian);
++          free(signed_grub_target);
++          free(signed_shim_target);
++        } /* TRUENAS EDIT END */
++
+       free (img_mac);
+       free (img32);
+       free (img64);
+       free (efidir_efi_boot);
+ 
+       efiimgfat = grub_util_path_concat (2, iso9660_dir, "efi.img");
+-      rv = grub_util_exec ((const char * []) { "mformat", "-C", "-f", "2880", "-L", "16", "-i",
++      rv = grub_util_exec ((const char * []) { "mformat", "-C", "-T", "16384", "-L", "16", "-i",
+ 	    efiimgfat, "::", NULL });
+       if (rv != 0)
+ 	grub_util_error ("`%s` invocation failed\n", "mformat");


### PR DESCRIPTION
When building the ISO we use grub-mkrescue to setup the outer GRUB on the ISO that's used to boot the actual installer, but mkrescue sadly has no native support to copy over the signed shim, so add that but only enable it through an environment variable so that we do not have to vet this overly closely as it won't affect any normal grub use anyway, even less so as mkrescue is used rather rarely on running systems. This patch would only be effective when `TRUENAS_CD_BUILDER_SHIM_QUIRK` is set during ISO creation. [Inspired by Proxmox Patch](https://git.proxmox.com/?p=grub2.git;a=blob;f=debian/patches/proxmox-mkrescue-install-signed-shim.patch;h=547097d8bfd6c66f3cead8a630ee802a12ac0c10;hb=043582b)

### Testing
- [Scale Build (In progress)](http://jenkins.eng.ixsystems.net:8080/job/master/job/custom/1096/)
- Verified that the ISO boots successfully with Secure Boot enabled [using this commit](https://github.com/truenas/scale-build/commit/d21ad980306963f99c96489bafc9e97e5a90ec09) (to be merged once TrueNAS `shim`/`grub-signed` packages are merged after getting our shim signed).