### PR TITLE
Fix grub-efi-amd64-signed dependency conflict for Trixie

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,9 @@
+grub2 (2.12-9) UNRELEASED; urgency=medium
+
+  * Match Debian version to fix grub-efi-amd64-signed dependency conflict
+
+ -- Ameer Hamza <ameer.hamza@truenas.com>  Wed, 24 Sep 2025 15:45:00 +0500
+
 grub2 (2.12-9+truenas1) unstable; urgency=medium
 
   * Update to Debian Trixie version 2.12-9 for compatibility


### PR DESCRIPTION
Trixie's grub-efi-amd64-signed package enforces strict version matching (grub-common = 2.12-9), whereas Bookworm had relaxed version requirements. Our grub-common package versioned as `2.12-9+truenas1` fails to meet this exact dependency. To fix this, we drop the `+truenas1` suffix and use version `2.12-9`. We also set the distribution to `UNRELEASED` because scale-build runs `dch` during each build, which would otherwise increment the version automatically. This ensures our grub packages version stays at exactly `2.12-9`, maintaining compatibility with Debian's signed GRUB package.
Once we merge this (After successful jenkins build), [grub-efi-amd64-signed package](https://github.com/truenas/scale-build/commit/eb3ccac9cb37f7a3ad3567f1e598ebaf9a66f11f)  will be re-added to scale_build.

### Testing
[Successful Scale Build](http://jenkins.eng.ixsystems.net:8080/job/master/job/custom/1564/) (In Progress).